### PR TITLE
Adding Docs, Updating Deps, Minor Bigfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ build/Release
 # Dependency directories
 node_modules/
 jspm_packages/
+.pnpm-store/
 
 # Snowpack dependency directory (https://snowpack.dev/)
 web_modules/

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ export class HelloController {
     },
     allowedRoles: ['admin'] // Only use if you've mapped the req.user.roleNames, see auth middleware section
   })
-  asyn postData(req, res) {
+  async postData(req, res) {
     // Do something with the data
     return { foo: 'bar' };
   }
@@ -107,7 +107,7 @@ app.listen(3000, () => {
 
 This framework expects the auth middleware to create a `User` object on the request. This object should have a `roleNames` property that is an array of strings. This is used for role-based access control. If you do not specify roles in your controller annotations, it will only do authentication, not authorization.
 
-For more information on the user object, see the [User interface](src/entity/User.ts).
+For more information on the user object, see the [User interface](src/entity/User.ts). **Full reference (bootstrap, errors, Swagger, constraints):** see [docs/](docs/README.md).
 
 ## Api Response / Errors
 

--- a/docs/01-framework-overview.md
+++ b/docs/01-framework-overview.md
@@ -1,0 +1,61 @@
+# Framework Overview
+
+## Purpose
+
+**@lreading/ts-express-framework** is an opinionated TypeScript framework for bootstrapping REST APIs on Node.js using Express. It provides decorator-based controller and route definition, convention-based HTTP status mapping, built-in error translation, role-based access control (RBAC), and optional Swagger/OpenAPI document generation.
+
+**Source:** `package.json` (description), `README.md`.
+
+---
+
+## Design Philosophy
+
+1. **Decorator-driven API surface**  
+   Controllers and routes are defined via class and method decorators. Metadata is stored with `reflect-metadata` and read at startup when routes are registered.
+
+2. **Zero-argument controllers**  
+   Controllers must be constructible with `new ControllerClass()` and no arguments. The framework does not provide dependency injection; it instantiates each controller once per application lifecycle. See [Dependency Injection & Services](05-dependency-injection-services.md).
+
+3. **Return value as response body**  
+   Handler methods return domain values (objects, primitives, or `null`). The framework maps return values and HTTP verbs to status codes and sends JSON. Controllers do not call `res.status()` or `res.json()` directly for success paths.
+
+4. **Exception-based error signaling**  
+   Errors are signaled by throwing framework error classes (e.g. `BadRequestError`, `NotFoundError`). The framework catches these and converts them to HTTP responses with appropriate status and body.
+
+5. **Middleware-compatible**  
+   Authentication and other cross-cutting concerns are delegated to Express middleware. The framework expects an `authMiddleware` that populates `req.user` for RBAC. Route registration composes this middleware with optional RBAC checks.
+
+6. **Swagger as a side effect of registration**  
+   OpenAPI 3.0 documentation is generated from the same route metadata used for registration, written to a file when `swaggerDocLocation` is provided. No separate DSL is required; decorator options drive the docs.
+
+---
+
+## What Problems It Solves
+
+- **Consistent REST semantics:** Standard mapping of HTTP verb + return value to status codes (e.g. POST → 201 Created, GET → 200 OK, DELETE/PATCH → 204 No Content).
+- **Centralized error handling:** One place (the wrapper in `RequestDecorator`) where `ApiError` subclasses are translated to HTTP status and body.
+- **RBAC without boilerplate:** Declarative `allowedRoles` and `allowAnonymous` on routes; the framework composes auth middleware and RBAC middleware.
+- **Documentation from code:** OpenAPI document generated from route definitions, including summary, description, example response, body definition, and parameters.
+
+---
+
+## What Opinions It Enforces
+
+| Opinion | Enforcement |
+|--------|-------------|
+| Controllers are classes with a no-arg constructor | `init.ts` checks `design:paramtypes` and throws if the controller has constructor parameters. |
+| Routes are class methods decorated with `@Get`, `@Post`, etc. | Only methods with these decorators are registered; metadata key is `'routes'`. |
+| Success response shape is determined by HTTP verb and return value | `getResponseWrapper()` in `src/decorators/Request.ts` maps verb + body to `ApiResponse` (e.g. POST → Created, GET → Ok). |
+| Returning `null` means 404 | `getResponseWrapper` returns `response.notFound()` when `body === null`. |
+| Errors are thrown, not returned | Only thrown `ApiError` (and subclasses) are converted to error responses; non-`ApiError` throwables become 500. |
+| Auth is middleware; user is on `req.user` | RBAC and docs assume `User` with `roleNames`; see `types/express/index.d.ts` and `src/entity/User.ts`. |
+| Response body is JSON | `ApiResponse.toResponse()` uses `res.status(code).json(data)`; `RedirectResponse` overrides to use `res.redirect()`. |
+
+---
+
+## Key Files
+
+- **Bootstrap:** `src/init.ts` — `registerControllers()`, controller instantiation, route registration, middleware composition, optional Swagger generation.
+- **Decorators:** `src/decorators/Controller.ts`, `src/decorators/Request.ts`, `src/decorators/Get.ts` (and other verbs).
+- **Metadata keys:** `'prefix'` (controller), `'routes'` (array of `RouteDefinition`).
+- **Entry point:** `src/index.ts` — re-exports and `import 'reflect-metadata'`.

--- a/docs/01-framework-reference.md
+++ b/docs/01-framework-reference.md
@@ -1,0 +1,197 @@
+# Framework Reference
+
+Single reference for **@lreading/ts-express-framework**: bootstrap, controllers, responses, errors, middleware, Swagger. Aligned with real usage (e.g. Riskize API).
+
+---
+
+## Bootstrap
+
+- **Entry:** Call `registerControllers(config)` with your Express app. You create the app yourself; the framework only registers routes and optional Swagger.
+- **reflect-metadata:** Must run before decorators. Import from `@lreading/ts-express-framework` before loading controller classes (the package imports `reflect-metadata` at entry).
+
+**Config:**
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `app` | Yes | Express instance |
+| `controllers` | Yes | Array of controller **classes** (not instances) |
+| `authMiddleware` | Yes | One middleware function or **array** of middleware functions |
+| `swaggerDocLocation` | No | If set, writes OpenAPI 3.0 JSON to this path |
+
+**Example (Riskize-style):**
+
+```ts
+import { Express } from 'express';
+import { registerControllers } from '@lreading/ts-express-framework';
+import { AuthController } from './Auth';
+import { ProjectController } from './Project';
+// ... other controllers
+import { isAuthenticated } from '../middleware';
+import { csrfSynchronisedProtection } from '../util';
+
+export const addRoutes = (app: Express): void => {
+  registerControllers({
+    app,
+    controllers: [AuthController, ProjectController, /* ... */],
+    swaggerDocLocation: 'swagger.json',
+    authMiddleware: [isAuthenticated, csrfSynchronisedProtection],
+  });
+};
+```
+
+---
+
+## Controllers
+
+- **Class** with `@Controller(prefix)`. Prefix is a path segment (e.g. `'/api/v1/projects'`). Default `''`.
+- **Constructor:** Must take **zero arguments**. The class you pass to `registerControllers` must be instantiable with `new ControllerClass()`. You may extend a base class whose constructor takes arguments, as long as the **registered** class has a no-arg constructor that supplies them (e.g. `constructor() { super(Entity, new EntityService()); }`).
+- **Routes:** Methods decorated with `@Get(path, options)`, `@Post(path, options)`, `@Put`, `@Patch`, `@Delete`. Path is Express-style (e.g. `'/'`, `'/:id'`, `'/:projectId/alternatives'`).
+- **Handler signature:** Method is called with `(req, res)`. You may omit `res` if unused. Return value becomes the response body; throw framework errors for error responses. Do not call `res.status()` / `res.json()` for the normal success path—the framework does that.
+
+**Route options (all optional):**
+
+| Option | Purpose |
+|--------|---------|
+| `allowAnonymous` | If true, auth middleware is skipped for this route |
+| `summary` | OpenAPI operation summary |
+| `description` | OpenAPI operation description |
+| `bodyDefinition` | `{ description?, required?, example }` for request body in Swagger |
+| `exampleResponse` | Example success body for Swagger (and documentation) |
+| `params` | `[{ name, in: 'path' \| 'query', required, type, description? }]` for Swagger |
+| `allowedRoles` | RBAC: user must have one of these roles (`req.user.roleNames`); only applied when `allowAnonymous` is false |
+
+**Minimal controller (anonymous GET):**
+
+```ts
+@Controller('/api/v1/config')
+export class ConfigController {
+  @Get('/', {
+    allowAnonymous: true,
+    summary: 'System Configuration',
+    description: 'Gets the configuration for the UI',
+    exampleResponse: { someConfig: 'value' },
+  })
+  async getConfig() {
+    return ConfigResponse.fromConfig();
+  }
+}
+```
+
+**Controller with auth and body (Riskize-style):**
+
+```ts
+@Controller('/api/v1/auth')
+export class AuthController {
+  constructor() {
+    // No DI: instantiate services in constructor if needed
+    this.userService = new AppUserService();
+  }
+
+  @Post('/register', {
+    allowAnonymous: true,
+    summary: 'Register a new user',
+    bodyDefinition: { description: 'Registration Body', required: true, example: { email: 'a@b.com', password: 'p', confirmPassword: 'p' } },
+    exampleResponse: { id: 1, email: 'nobody@nowhere.com' },
+  })
+  async register(req: Request) {
+    if (!req.body.password || req.body.password !== req.body.confirmPassword) {
+      throw new BadRequestError(req, 'Password and confirm password must match');
+    }
+    const entity = await this.userService.create(/* ... */);
+    return { id: entity.id, email: entity.email };
+  }
+}
+```
+
+**Resource controller extending a base (Riskize-style):**
+
+```ts
+@Controller('/api/v1/projects')
+export class ProjectController extends EntityController<Project> {
+  constructor() {
+    super(Project, new ProjectService());
+  }
+
+  @Get('/', { summary: 'Get all projects', exampleResponse: [/* ... */] })
+  async getAll(req: Request) {
+    return await super.getAll(req);
+  }
+
+  @Get('/:id', {
+    params: [{ name: 'id', in: 'path', required: true, type: 'number', description: 'Project ID' }],
+    exampleResponse: { id: 1, name: 'Project 1', /* ... */ },
+  })
+  async getById(req: Request) {
+    return await super.getById(req);
+  }
+
+  @Post('/', { bodyDefinition: { required: true, example: { name: 'Project 1', /* ... */ } }, exampleResponse: { id: 1, /* ... */ } })
+  async insert(req: Request) {
+    return await super.insert(req);
+  }
+
+  @Put('/:id', { params: [/* ... */], bodyDefinition: { required: true, example: { id: 1, /* ... */ } } })
+  async update(req: Request) {
+    return await super.update(req);
+  }
+
+  @Delete('/:id', { params: [{ name: 'id', in: 'path', required: true, type: 'number' }] })
+  async delete(req: Request) {
+    return await super.delete(req);
+  }
+}
+```
+
+---
+
+## Response and status codes
+
+- **Success:** The framework maps return value and HTTP method to status and sends JSON.
+  - **GET:** 200, body = return value.
+  - **POST:** 201 Created, body = return value.
+  - **PUT:** 202 Accepted, body = return value.
+  - **PATCH / DELETE:** 204 No Content (body not sent).
+  - **Return `null`:** 404 Not Found.
+- **Body:** Response body is the raw return value (no envelope like `{ data }`). Use `res.status().json(data)` only for success; do not mix with returning a value.
+
+---
+
+## Errors
+
+Throw framework error classes. The wrapper catches them and sends the corresponding HTTP response. Pass `req` into each so logging has method, path, and optional user.
+
+| Error | Status | Usage |
+|-------|--------|--------|
+| `BadRequestError` | 400 | `throw new BadRequestError(req, 'message')` |
+| `UnauthorizedError` | 401 | `throw new UnauthorizedError(req)` |
+| `ForbiddenError` | 403 | `throw new ForbiddenError(req)` |
+| `NotFoundError` | 404 | `throw new NotFoundError(req)` |
+| `RedirectError` | 302 | `throw new RedirectError(req, redirectUrl)`; URL on `RedirectError.redirectLocation` |
+| Other `ApiError` / non-ApiError | 500 | Generic server error |
+
+Errors can be thrown from controllers or from services called by controllers; the wrapper still turns them into HTTP responses. Do not throw plain `Error` for client errors—use `BadRequestError` etc., or the response will be 500.
+
+---
+
+## Middleware
+
+- **Per-route:** Each route gets middleware composed by the framework: either pass-through only (`allowAnonymous: true`) or `authMiddleware` then optional RBAC.
+- **Auth:** Your `authMiddleware` runs for every non-anonymous route. It should set `req.user` (and optionally send 401). For RBAC, `req.user` must have `roleNames: string[]`; the framework checks it against `allowedRoles` when that option is set.
+- **Order:** auth (all functions in `authMiddleware`) → RBAC (if `allowedRoles` set and not anonymous) → route handler. The framework does not attach controller-level middleware; only route-level.
+
+---
+
+## Swagger / OpenAPI
+
+- **Source:** Route metadata from decorators (`summary`, `description`, `exampleResponse`, `bodyDefinition`, `params`). No separate DSL.
+- **When:** If `swaggerDocLocation` is provided, the framework writes the OpenAPI document after registering all routes. Path params in routes use Express style (`:id`); the doc uses OpenAPI style (`{id}`).
+- **You must supply:** `summary`, `description`, `exampleResponse`, `bodyDefinition`, `params` in decorator options for them to appear; types are not inferred.
+
+---
+
+## Quick reference (agents)
+
+- **Bootstrap:** `registerControllers({ app, controllers, swaggerDocLocation?, authMiddleware })`. `authMiddleware` can be a single function or array.
+- **Controllers:** Class with `@Controller(prefix)`, zero-arg constructor, methods with `@Get(path, options)` etc. One instance per controller class for app lifetime.
+- **Response:** Return value → body; GET→200, POST→201, PUT→202, PATCH/DELETE→204; `null`→404. Errors by throwing `BadRequestError(req, message)`, `NotFoundError(req)`, etc.
+- **No built-in DI.** Services are typically created in the controller constructor (`new MyService()`). Base classes with constructor args are fine if the registered subclass has a no-arg constructor.

--- a/docs/02-constraints-and-extension.md
+++ b/docs/02-constraints-and-extension.md
@@ -1,0 +1,25 @@
+# Constraints and Extension
+
+## Implicit rules
+
+1. **Zero-arg constructor:** The class passed to `registerControllers` must be constructible with `new ControllerClass()`. Enforced via `design:paramtypes`; base classes may have parameters if the registered subclass supplies them.
+2. **Return `null` → 404.** No other special return values.
+3. **Response body = return value.** No standard envelope; `toResponse` uses `res.status(code).json(data)`.
+4. **Path building:** `fullPath = (prefix.startsWith('/') ? '' : '/') + prefix + route.path`. Use leading slashes consistently (e.g. `@Get('/:id')`).
+5. **RBAC:** Applied only when `allowedRoles` is non-empty and `allowAnonymous` is false. Requires `req.user.roleNames`.
+6. **One instance per controller class** for the app lifetime.
+7. **Verb decorators:** Second argument (options) is required by the decorator signature; all fields inside it are optional.
+
+## Extending
+
+- **Auth:** Supply your own `authMiddleware`; set `req.user` for RBAC. No framework change needed.
+- **New routes/controllers:** Add classes and pass them in `controllers`. No framework change.
+- **Custom error types:** Subclass `ApiError`, implement `logMessage(logger)`. Treated as 500 unless you fork/patch `getErrorResponse` in the framework.
+- **Swagger:** Post-process the generated file or extend `SwaggerJsonGenerator` and call it after registration.
+
+## Do not
+
+- Add constructor parameters expecting the framework to inject them.
+- Call `res.status()` / `res.json()` for the success path and also return a value (double-send).
+- Rely on Express error middleware for route errors; the wrapper catches and responds.
+- Overwrite metadata keys `'prefix'` or `'routes'` on the controller constructor.

--- a/docs/03-project-and-testing.md
+++ b/docs/03-project-and-testing.md
@@ -1,0 +1,31 @@
+# Project Structure and Testing
+
+## Project structure (aligned with real usage)
+
+Typical layout for an app using this framework:
+
+```
+src/
+  controller/
+    index.ts          # addRoutes(app): imports all controllers, calls registerControllers({ app, controllers, swaggerDocLocation, authMiddleware })
+    Auth.ts
+    Project.ts
+    EntityController.ts   # Optional base class for CRUD; registered controllers extend it with super(Entity, new EntityService())
+  middleware/
+    auth.ts           # e.g. isAuthenticated: check req.session.user, 401 or next()
+  service/
+  entity/
+  ...
+swagger.json          # Generated when swaggerDocLocation is set
+```
+
+- **Bootstrap:** One function (e.g. `addRoutes(app)`) that receives the Express app and calls `registerControllers` with the controller class array and auth middleware. The app is created elsewhere (e.g. server entry); routes are attached by calling this function.
+- **Controllers:** One file per controller (or per feature). Export the class; import all of them in the bootstrap file so decorators run and the classes are passed to `registerControllers`.
+- **Auth:** Middleware can use sessions (`req.session.user`) or JWT; for RBAC the framework expects `req.user.roleNames`. If you only use `allowAnonymous` vs authenticated, you do not need to set `req.user`.
+
+## Testing
+
+- **Handlers:** Instantiate the controller, call the method with mock `req` and `res`, assert on return value or thrown errors. Ensure `reflect-metadata` is loaded if tests touch registration or metadata.
+- **Errors:** Use framework error classes in tests as in production; assert that the correct status/body are sent (e.g. via integration tests against a test app) or mock the response layer.
+- **Services:** Not managed by the framework; test as usual. Controllers can be tested with service mocks (e.g. replace the service module or inject test doubles via a pattern you own).
+- **Middleware:** Test auth and RBAC in isolation with mock `req`/`res`/`next`; optionally run integration tests with the real stack.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# Internal Framework Documentation
+
+Authoritative docs for **@lreading/ts-express-framework**. Aligned with real usage (e.g. Riskize API). Suitable for maintainers and for AI/agents that need to reason about or use the framework.
+
+---
+
+## Document index
+
+| Doc | Contents |
+|-----|----------|
+| [01-framework-reference.md](01-framework-reference.md) | Bootstrap, controllers, response/status, errors, middleware, Swagger. Examples from real usage. |
+| [02-constraints-and-extension.md](02-constraints-and-extension.md) | Implicit rules, extension points, what not to do. |
+| [03-project-and-testing.md](03-project-and-testing.md) | Project layout (Riskize-style), testing controllers and middleware. |
+
+---
+
+## Quick reference for agents
+
+- **Bootstrap:** `registerControllers({ app, controllers, swaggerDocLocation?, authMiddleware })`. `authMiddleware` is one function or an array. Call after creating the Express app; ensure controller classes are imported so decorators run.
+- **Controllers:** Class with `@Controller(prefix)`, **zero-arg constructor**, methods with `@Get(path, options)`, `@Post(path, options)`, `@Put`, `@Patch`, `@Delete`. Options: `allowAnonymous`, `summary`, `description`, `bodyDefinition`, `exampleResponse`, `params`, `allowedRoles`. One instance per controller class.
+- **Response:** Return value = response body. GET→200, POST→201, PUT→202, PATCH/DELETE→204; return `null` → 404. Errors: throw `BadRequestError(req, message)`, `NotFoundError(req)`, `UnauthorizedError(req)`, `ForbiddenError(req)`, `RedirectError(req, url)`, or other `ApiError` (→500).
+- **No DI.** Controllers create services in the constructor (e.g. `new MyService()`). Registered class may extend a base with constructor args if the subclass has a no-arg constructor that calls `super(...)`.
+- **Metadata:** `'prefix'`, `'routes'` on controller constructor; `design:paramtypes` must be empty for the registered class. `RedirectError.redirectLocation` is the redirect URL.

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/express": "^4.17.23",
+    "@types/express": "^4.17.25",
     "@types/jsonwebtoken": "^8.5.9",
-    "@types/node": "^18.19.120",
+    "@types/node": "^18.19.130",
     "@types/triple-beam": "^1.3.5",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
@@ -32,7 +32,7 @@
   "dependencies": {
     "@lreading/ts-logger": "^1.0.12",
     "class-transformer": "^0.5.1",
-    "jsonwebtoken": "^9.0.2",
+    "jsonwebtoken": "^9.0.3",
     "jwks-rsa": "^2.1.5",
     "logform": "^2.7.0",
     "openapi-types": "^12.1.3",
@@ -41,7 +41,8 @@
   },
   "pnpm": {
     "overrides": {
-      "micromatch@<4.0.8": ">=4.0.8"
+      "micromatch@<4.0.8": ">=4.0.8",
+      "minimatch": ">=9.0.7"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lreading/ts-express-framework",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Typescript Express Framework for REST APIs",
   "main": "dist/index.js",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   micromatch@<4.0.8: '>=4.0.8'
+  minimatch: '>=9.0.7'
 
 importers:
 
@@ -18,8 +19,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       jsonwebtoken:
-        specifier: ^9.0.2
-        version: 9.0.2
+        specifier: ^9.0.3
+        version: 9.0.3
       jwks-rsa:
         specifier: ^2.1.5
         version: 2.1.5
@@ -37,14 +38,14 @@ importers:
         version: 4.9.0
     devDependencies:
       '@types/express':
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^4.17.25
+        version: 4.17.25
       '@types/jsonwebtoken':
         specifier: ^8.5.9
         version: 8.5.9
       '@types/node':
-        specifier: ^18.19.120
-        version: 18.19.120
+        specifier: ^18.19.130
+        version: 18.19.130
       '@types/triple-beam':
         specifier: ^1.3.5
         version: 1.3.5
@@ -62,7 +63,7 @@ importers:
         version: 4.1.5
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@18.19.120)(typescript@4.9.5)
+        version: 10.9.2(@types/node@18.19.130)(typescript@4.9.5)
       typescript:
         specifier: ^4.9.5
         version: 4.9.5
@@ -72,8 +73,8 @@ packages:
   '@babel/code-frame@7.12.11':
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
 
-  '@babel/helper-validator-identifier@7.27.1':
-    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.25.9':
@@ -88,17 +89,17 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@dabh/diagnostics@2.0.3':
-    resolution: {integrity: sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==}
+  '@dabh/diagnostics@2.0.8':
+    resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
 
-  '@eslint-community/eslint-utils@4.7.0':
-    resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@eslint-community/regexpp@4.12.1':
-    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   '@eslint/eslintrc@0.4.3':
@@ -118,8 +119,8 @@ packages:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/sourcemap-codec@1.5.4':
-    resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -143,8 +144,11 @@ packages:
     resolution: {integrity: sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==}
     engines: {node: '>=10.13.0'}
 
-  '@tsconfig/node10@1.0.11':
-    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+  '@so-ric/colorspace@1.1.6':
+    resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
+
+  '@tsconfig/node10@1.0.12':
+    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
 
   '@tsconfig/node12@1.0.11':
     resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
@@ -161,11 +165,11 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
-  '@types/express-serve-static-core@4.19.6':
-    resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
+  '@types/express-serve-static-core@4.19.8':
+    resolution: {integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==}
 
-  '@types/express@4.17.23':
-    resolution: {integrity: sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==}
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
@@ -179,8 +183,8 @@ packages:
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
-  '@types/node@18.19.120':
-    resolution: {integrity: sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==}
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -188,14 +192,17 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
-  '@types/semver@7.7.0':
-    resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
-  '@types/send@0.17.5':
-    resolution: {integrity: sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==}
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
 
-  '@types/serve-static@1.15.8':
-    resolution: {integrity: sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==}
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
@@ -263,8 +270,8 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-walk@8.3.4:
-    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
 
   acorn@7.4.1:
@@ -272,16 +279,16 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -332,14 +339,13 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
-
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -382,23 +388,27 @@ packages:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
+  color-convert@3.1.3:
+    resolution: {integrity: sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==}
+    engines: {node: '>=14.6'}
+
   color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  color-string@1.9.1:
-    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+  color-name@2.1.0:
+    resolution: {integrity: sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==}
+    engines: {node: '>=12.20'}
 
-  color@3.2.1:
-    resolution: {integrity: sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==}
+  color-string@2.1.4:
+    resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
+    engines: {node: '>=18'}
 
-  colorspace@1.1.4:
-    resolution: {integrity: sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+  color@5.0.3:
+    resolution: {integrity: sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==}
+    engines: {node: '>=18'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -423,8 +433,8 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  debug@4.4.1:
-    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -443,8 +453,8 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -472,11 +482,11 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
-  error-ex@1.3.2:
-    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
-  es-abstract@1.24.0:
-    resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
+  es-abstract@1.24.1:
+    resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
     engines: {node: '>= 0.4'}
 
   es-define-property@1.0.1:
@@ -542,8 +552,8 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  esquery@1.6.0:
-    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
   esrecurse@4.3.0:
@@ -575,11 +585,11 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.0.6:
-    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fastq@1.19.1:
-    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
@@ -622,6 +632,10 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -640,7 +654,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -732,9 +746,6 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
-  is-arrayish@0.3.2:
-    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
-
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
     engines: {node: '>= 0.4'}
@@ -775,8 +786,8 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-generator-function@1.1.0:
-    resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
 
   is-glob@4.0.3:
@@ -852,8 +863,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -871,19 +882,19 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  jsonwebtoken@9.0.2:
-    resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
 
-  jwa@1.4.2:
-    resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
   jwks-rsa@2.1.5:
     resolution: {integrity: sha512-IODtn1SwEm7n6GQZnQLY0oxKDrMh7n/jRH1MzE8mlxWMrh2NnMyOsXTebu8vJ1qCpmuTJcL4DdiE0E4h8jnwsA==}
     engines: {node: '>=10 < 13 || >=14'}
 
-  jws@3.2.2:
-    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -962,12 +973,9 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
-  minimatch@9.0.3:
-    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1112,8 +1120,8 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
-  resolve@1.22.10:
-    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+  resolve@1.22.11:
+    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
     hasBin: true
 
@@ -1152,8 +1160,8 @@ packages:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
 
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1205,9 +1213,6 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
-  simple-swizzle@0.2.2:
-    resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
-
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -1225,8 +1230,8 @@ packages:
   spdx-expression-parse@3.0.1:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
 
-  spdx-license-ids@3.0.21:
-    resolution: {integrity: sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==}
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -1386,8 +1391,8 @@ packages:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
 
-  which-typed-array@1.1.19:
-    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
 
   which@1.3.1:
@@ -1403,8 +1408,8 @@ packages:
     resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
     engines: {node: '>= 12.0.0'}
 
-  winston@3.17.0:
-    resolution: {integrity: sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==}
+  winston@3.19.0:
+    resolution: {integrity: sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==}
     engines: {node: '>= 12.0.0'}
 
   word-wrap@1.2.5:
@@ -1427,11 +1432,11 @@ snapshots:
     dependencies:
       '@babel/highlight': 7.25.9
 
-  '@babel/helper-validator-identifier@7.27.1': {}
+  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/highlight@7.25.9':
     dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.1.1
@@ -1442,29 +1447,29 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@dabh/diagnostics@2.0.3':
+  '@dabh/diagnostics@2.0.8':
     dependencies:
-      colorspace: 1.1.4
+      '@so-ric/colorspace': 1.1.6
       enabled: 2.0.0
       kuler: 2.0.0
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@7.32.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@7.32.0)':
     dependencies:
       eslint: 7.32.0
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/regexpp@4.12.1': {}
+  '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/eslintrc@0.4.3':
     dependencies:
-      ajv: 6.12.6
-      debug: 4.4.1
+      ajv: 6.14.0
+      debug: 4.4.3
       espree: 7.3.1
       globals: 13.24.0
       ignore: 4.0.6
       import-fresh: 3.3.1
-      js-yaml: 3.14.1
-      minimatch: 3.1.2
+      js-yaml: 3.14.2
+      minimatch: 10.2.4
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -1472,8 +1477,8 @@ snapshots:
   '@humanwhocodes/config-array@0.5.0':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.4.1
-      minimatch: 3.1.2
+      debug: 4.4.3
+      minimatch: 10.2.4
     transitivePeerDependencies:
       - supports-color
 
@@ -1481,17 +1486,17 @@ snapshots:
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
-  '@jridgewell/sourcemap-codec@1.5.4': {}
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@lreading/ts-logger@1.0.12':
     dependencies:
       logform: 2.7.0
-      winston: 3.17.0
+      winston: 3.19.0
       winston-transport: 4.9.0
 
   '@nodelib/fs.scandir@2.1.5':
@@ -1504,11 +1509,16 @@ snapshots:
   '@nodelib/fs.walk@1.2.8':
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.19.1
+      fastq: 1.20.1
 
   '@panva/asn1.js@1.0.0': {}
 
-  '@tsconfig/node10@1.0.11': {}
+  '@so-ric/colorspace@1.1.6':
+    dependencies:
+      color: 5.0.3
+      text-hex: 1.0.0
+
+  '@tsconfig/node10@1.0.12': {}
 
   '@tsconfig/node12@1.0.11': {}
 
@@ -1519,25 +1529,25 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 18.19.120
+      '@types/node': 18.19.130
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 18.19.120
+      '@types/node': 18.19.130
 
-  '@types/express-serve-static-core@4.19.6':
+  '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 18.19.120
+      '@types/node': 18.19.130
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
-      '@types/send': 0.17.5
+      '@types/send': 1.2.1
 
-  '@types/express@4.17.23':
+  '@types/express@4.17.25':
     dependencies:
       '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 4.19.6
+      '@types/express-serve-static-core': 4.19.8
       '@types/qs': 6.14.0
-      '@types/serve-static': 1.15.8
+      '@types/serve-static': 1.15.10
 
   '@types/http-errors@2.0.5': {}
 
@@ -1545,11 +1555,11 @@ snapshots:
 
   '@types/jsonwebtoken@8.5.9':
     dependencies:
-      '@types/node': 18.19.120
+      '@types/node': 18.19.130
 
   '@types/mime@1.3.5': {}
 
-  '@types/node@18.19.120':
+  '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
 
@@ -1557,35 +1567,39 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
-  '@types/semver@7.7.0': {}
+  '@types/semver@7.7.1': {}
 
-  '@types/send@0.17.5':
+  '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 18.19.120
+      '@types/node': 18.19.130
 
-  '@types/serve-static@1.15.8':
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 18.19.130
+
+  '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 18.19.120
-      '@types/send': 0.17.5
+      '@types/node': 18.19.130
+      '@types/send': 0.17.6
 
   '@types/triple-beam@1.3.5': {}
 
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5)':
     dependencies:
-      '@eslint-community/regexpp': 4.12.1
+      '@eslint-community/regexpp': 4.12.2
       '@typescript-eslint/parser': 6.21.0(eslint@7.32.0)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/type-utils': 6.21.0(eslint@7.32.0)(typescript@4.9.5)
       '@typescript-eslint/utils': 6.21.0(eslint@7.32.0)(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 7.32.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      semver: 7.7.2
+      semver: 7.7.4
       ts-api-utils: 1.4.3(typescript@4.9.5)
     optionalDependencies:
       typescript: 4.9.5
@@ -1598,7 +1612,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 7.32.0
     optionalDependencies:
       typescript: 4.9.5
@@ -1614,7 +1628,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@4.9.5)
       '@typescript-eslint/utils': 6.21.0(eslint@7.32.0)(typescript@4.9.5)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 7.32.0
       ts-api-utils: 1.4.3(typescript@4.9.5)
     optionalDependencies:
@@ -1628,11 +1642,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.1
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
-      minimatch: 9.0.3
-      semver: 7.7.2
+      minimatch: 10.2.4
+      semver: 7.7.4
       ts-api-utils: 1.4.3(typescript@4.9.5)
     optionalDependencies:
       typescript: 4.9.5
@@ -1641,14 +1655,14 @@ snapshots:
 
   '@typescript-eslint/utils@6.21.0(eslint@7.32.0)(typescript@4.9.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@7.32.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@7.32.0)
       '@types/json-schema': 7.0.15
-      '@types/semver': 7.7.0
+      '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@4.9.5)
       eslint: 7.32.0
-      semver: 7.7.2
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -1662,25 +1676,25 @@ snapshots:
     dependencies:
       acorn: 7.4.1
 
-  acorn-walk@8.3.4:
+  acorn-walk@8.3.5:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
   acorn@7.4.1: {}
 
-  acorn@8.15.0: {}
+  acorn@8.16.0: {}
 
-  ajv@6.12.6:
+  ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.17.1:
+  ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.6
+      fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1714,7 +1728,7 @@ snapshots:
       array-buffer-byte-length: 1.0.2
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
@@ -1729,16 +1743,11 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.4: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@5.0.4:
     dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -1786,26 +1795,24 @@ snapshots:
     dependencies:
       color-name: 1.1.4
 
+  color-convert@3.1.3:
+    dependencies:
+      color-name: 2.1.0
+
   color-name@1.1.3: {}
 
   color-name@1.1.4: {}
 
-  color-string@1.9.1:
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.2
+  color-name@2.1.0: {}
 
-  color@3.2.1:
+  color-string@2.1.4:
     dependencies:
-      color-convert: 1.9.3
-      color-string: 1.9.1
+      color-name: 2.1.0
 
-  colorspace@1.1.4:
+  color@5.0.3:
     dependencies:
-      color: 3.2.1
-      text-hex: 1.0.0
-
-  concat-map@0.0.1: {}
+      color-convert: 3.1.3
+      color-string: 2.1.4
 
   create-require@1.1.1: {}
 
@@ -1841,7 +1848,7 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  debug@4.4.1:
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
@@ -1859,7 +1866,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  diff@4.0.2: {}
+  diff@4.0.4: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -1888,11 +1895,11 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
-  error-ex@1.3.2:
+  error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
 
-  es-abstract@1.24.0:
+  es-abstract@1.24.1:
     dependencies:
       array-buffer-byte-length: 1.0.2
       arraybuffer.prototype.slice: 1.0.4
@@ -1947,7 +1954,7 @@ snapshots:
       typed-array-byte-offset: 1.0.4
       typed-array-length: 1.0.7
       unbox-primitive: 1.1.0
-      which-typed-array: 1.1.19
+      which-typed-array: 1.1.20
 
   es-define-property@1.0.1: {}
 
@@ -1994,10 +2001,10 @@ snapshots:
       '@babel/code-frame': 7.12.11
       '@eslint/eslintrc': 0.4.3
       '@humanwhocodes/config-array': 0.5.0
-      ajv: 6.12.6
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1
+      debug: 4.4.3
       doctrine: 3.0.0
       enquirer: 2.4.1
       escape-string-regexp: 4.0.0
@@ -2005,7 +2012,7 @@ snapshots:
       eslint-utils: 2.1.0
       eslint-visitor-keys: 2.1.0
       espree: 7.3.1
-      esquery: 1.6.0
+      esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 6.0.1
@@ -2016,16 +2023,16 @@ snapshots:
       import-fresh: 3.3.1
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 10.2.4
       natural-compare: 1.4.0
       optionator: 0.9.4
       progress: 2.0.3
       regexpp: 3.2.0
-      semver: 7.7.2
+      semver: 7.7.4
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
       table: 6.9.0
@@ -2042,7 +2049,7 @@ snapshots:
 
   esprima@4.0.1: {}
 
-  esquery@1.6.0:
+  esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
 
@@ -2070,9 +2077,9 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.0.6: {}
+  fast-uri@3.1.0: {}
 
-  fastq@1.19.1:
+  fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
 
@@ -2117,6 +2124,8 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  generator-function@2.0.1: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -2150,7 +2159,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 10.2.4
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -2236,8 +2245,6 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
-  is-arrayish@0.3.2: {}
-
   is-async-function@2.1.1:
     dependencies:
       async-function: 1.0.0
@@ -2280,9 +2287,10 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-generator-function@1.1.0:
+  is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
+      generator-function: 2.0.1
       get-proto: 1.0.1
       has-tostringtag: 1.0.2
       safe-regex-test: 1.1.0
@@ -2330,7 +2338,7 @@ snapshots:
 
   is-typed-array@1.1.15:
     dependencies:
-      which-typed-array: 1.1.19
+      which-typed-array: 1.1.20
 
   is-weakmap@2.0.2: {}
 
@@ -2353,7 +2361,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.1:
+  js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -2368,9 +2376,9 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  jsonwebtoken@9.0.2:
+  jsonwebtoken@9.0.3:
     dependencies:
-      jws: 3.2.2
+      jws: 4.0.1
       lodash.includes: 4.3.0
       lodash.isboolean: 3.0.3
       lodash.isinteger: 4.0.4
@@ -2379,9 +2387,9 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.2
+      semver: 7.7.4
 
-  jwa@1.4.2:
+  jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
       ecdsa-sig-formatter: 1.0.11
@@ -2389,18 +2397,18 @@ snapshots:
 
   jwks-rsa@2.1.5:
     dependencies:
-      '@types/express': 4.17.23
+      '@types/express': 4.17.25
       '@types/jsonwebtoken': 8.5.9
-      debug: 4.4.1
+      debug: 4.4.3
       jose: 2.0.7
       limiter: 1.1.5
       lru-memoizer: 2.3.0
     transitivePeerDependencies:
       - supports-color
 
-  jws@3.2.2:
+  jws@4.0.1:
     dependencies:
-      jwa: 1.4.2
+      jwa: 2.0.1
       safe-buffer: 5.2.1
 
   keyv@4.5.4:
@@ -2474,13 +2482,9 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  minimatch@3.1.2:
+  minimatch@10.2.4:
     dependencies:
-      brace-expansion: 1.1.12
-
-  minimatch@9.0.3:
-    dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.4
 
   ms@2.1.3: {}
 
@@ -2491,7 +2495,7 @@ snapshots:
   normalize-package-data@2.5.0:
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.10
+      resolve: 1.22.11
       semver: 5.7.2
       validate-npm-package-license: 3.0.4
 
@@ -2501,7 +2505,7 @@ snapshots:
       chalk: 2.4.2
       cross-spawn: 6.0.6
       memorystream: 0.3.1
-      minimatch: 3.1.2
+      minimatch: 10.2.4
       pidtree: 0.3.1
       read-pkg: 3.0.0
       shell-quote: 1.8.3
@@ -2551,7 +2555,7 @@ snapshots:
 
   parse-json@4.0.0:
     dependencies:
-      error-ex: 1.3.2
+      error-ex: 1.3.4
       json-parse-better-errors: 1.0.2
 
   path-is-absolute@1.0.1: {}
@@ -2604,7 +2608,7 @@ snapshots:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
@@ -2626,7 +2630,7 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
-  resolve@1.22.10:
+  resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
       path-parse: 1.0.7
@@ -2667,7 +2671,7 @@ snapshots:
 
   semver@5.7.2: {}
 
-  semver@7.7.2: {}
+  semver@7.7.4: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -2733,10 +2737,6 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
-  simple-swizzle@0.2.2:
-    dependencies:
-      is-arrayish: 0.3.2
-
   slash@3.0.0: {}
 
   slice-ansi@4.0.0:
@@ -2748,16 +2748,16 @@ snapshots:
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.21
+      spdx-license-ids: 3.0.23
 
   spdx-exceptions@2.5.0: {}
 
   spdx-expression-parse@3.0.1:
     dependencies:
       spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.21
+      spdx-license-ids: 3.0.23
 
-  spdx-license-ids@3.0.21: {}
+  spdx-license-ids@3.0.23: {}
 
   sprintf-js@1.0.3: {}
 
@@ -2778,7 +2778,7 @@ snapshots:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-object-atoms: 1.1.1
 
   string.prototype.trim@1.2.10:
@@ -2787,7 +2787,7 @@ snapshots:
       call-bound: 1.0.4
       define-data-property: 1.1.4
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-object-atoms: 1.1.1
       has-property-descriptors: 1.0.2
 
@@ -2828,7 +2828,7 @@ snapshots:
 
   table@6.9.0:
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
       string-width: 4.2.3
@@ -2848,19 +2848,19 @@ snapshots:
     dependencies:
       typescript: 4.9.5
 
-  ts-node@10.9.2(@types/node@18.19.120)(typescript@4.9.5):
+  ts-node@10.9.2(@types/node@18.19.130)(typescript@4.9.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.120
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
+      '@types/node': 18.19.130
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.2
+      diff: 4.0.4
       make-error: 1.3.6
       typescript: 4.9.5
       v8-compile-cache-lib: 3.0.1
@@ -2947,13 +2947,13 @@ snapshots:
       is-async-function: 2.1.1
       is-date-object: 1.1.0
       is-finalizationregistry: 1.1.1
-      is-generator-function: 1.1.0
+      is-generator-function: 1.1.2
       is-regex: 1.2.1
       is-weakref: 1.1.1
       isarray: 2.0.5
       which-boxed-primitive: 1.1.1
       which-collection: 1.0.2
-      which-typed-array: 1.1.19
+      which-typed-array: 1.1.20
 
   which-collection@1.0.2:
     dependencies:
@@ -2962,7 +2962,7 @@ snapshots:
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
 
-  which-typed-array@1.1.19:
+  which-typed-array@1.1.20:
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.8
@@ -2986,10 +2986,10 @@ snapshots:
       readable-stream: 3.6.2
       triple-beam: 1.4.1
 
-  winston@3.17.0:
+  winston@3.19.0:
     dependencies:
       '@colors/colors': 1.6.0
-      '@dabh/diagnostics': 2.0.3
+      '@dabh/diagnostics': 2.0.8
       async: 3.2.6
       is-stream: 2.0.1
       logform: 2.7.0

--- a/src/decorators/Request.ts
+++ b/src/decorators/Request.ts
@@ -27,7 +27,7 @@ const getErrorResponse = (err: ApiError, res: Response): Response | void => {
     return response.unauthorized().toResponse(res);
   }
   if (err instanceof RedirectError) {
-    const redirectLocation = (err as RedirectError).readirectLocation;
+    const redirectLocation = (err as RedirectError).redirectLocation;
     return response.redirect(redirectLocation).toResponse(res);
   }
   return response.serverError().toResponse(res);

--- a/src/documentation/Docs.ts
+++ b/src/documentation/Docs.ts
@@ -37,6 +37,8 @@ export class SwaggerJsonGenerator {
       return 'delete';
     case METHOD.GET:
       return 'get';
+    case METHOD.PATCH:
+      return 'patch';
     case METHOD.POST:
       return 'post';
     case METHOD.PUT:
@@ -103,10 +105,7 @@ export class SwaggerJsonGenerator {
       description: 'Success Response',
       content: {
         'application/json': {
-          example: {
-            status: 200,
-            body: route.exampleResponse || {}
-          }
+          example: route.exampleResponse !== undefined ? route.exampleResponse : {}
         }
       }
     };

--- a/src/documentation/responses/index.ts
+++ b/src/documentation/responses/index.ts
@@ -32,7 +32,15 @@ export const getResponses = (successResponse: OpenAPIV3.ResponseObject, method: 
     };
   case METHOD.DELETE:
     return {
-      200: successResponse,
+      204: successResponse,
+      401: UnauthorizedRequestResponse,
+      404: NotFoundResponse,
+      500: ServerErrorResponse
+    };
+  case METHOD.PATCH:
+    return {
+      204: successResponse,
+      400: BadRequestResponse,
       401: UnauthorizedRequestResponse,
       404: NotFoundResponse,
       500: ServerErrorResponse

--- a/src/errors/RedirectError.ts
+++ b/src/errors/RedirectError.ts
@@ -4,14 +4,14 @@ import { TSLogger } from '@lreading/ts-logger';
 import { ApiError } from './ApiError';
 
 export class RedirectError extends ApiError {
-  public readonly readirectLocation: string;
+  public readonly redirectLocation: string;
 
   constructor(req: Request, redirectLocation: string) {
     super(req);
-    this.readirectLocation = redirectLocation;
+    this.redirectLocation = redirectLocation;
   }
 
   logMessage(logger: TSLogger): void {
-    logger.audit(`Redirecting request to: ${this.readirectLocation}`);
+    logger.audit(`Redirecting request to: ${this.redirectLocation}`);
   }
 }


### PR DESCRIPTION
- Added docs
- Fixed typo in property, while technically breaking it's really an internal prop, so no major bump at this time
- Fixed bug in swagger doc generation that was using the old pattern for "success" statuses including the HTTP status in the body.
  - One day, we will give the same treatment to error responses, but that is a breaking change and will require a major version bump
- Fixed typo in readme, added link to docs
- Fixed bug where swagger docs gen would error on PATCH requests

The docs are AI generated.  I did a bit of UAC by asking another agent to build an API using this framework with only the docs for reference.  The generated API was functional and worked as expected on the first try.  While not a perfect test, it gives me some confidence that there's enough context for agents and hopefully people to use the docs.